### PR TITLE
Link to code of conduct gives 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](/CONTRIBUTING.md)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md) 
 
 A 3-hour workshop exploring scanning for secrets in code and containers.
 


### PR DESCRIPTION
The link to the file `CODE_OF_CONDUCT.md` is in lowercase and thus gives a 404 when pressed/followed.