### PR TITLE
build(workflow): bump actions in secret-scanning

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: TruffleHog OSS


### PR DESCRIPTION
Bumping third party actions, which should mitigate the warnings about using deprecated node version in the workflows:

* bump actions/checkout from v3 to v4