### PR TITLE
chore: bump dependencies

### DIFF
--- a/ex-03/src/package.json
+++ b/ex-03/src/package.json
@@ -15,6 +15,6 @@
         "@azure/msal-node": "^2.13.1"
     },
     "devDependencies": {
-        "tap": "^18.6.1"
+        "tap": "^21.0.1"
     }
 }

--- a/ex-03/src/package.json
+++ b/ex-03/src/package.json
@@ -12,7 +12,7 @@
     "author": "Lars Kåre Skjørestad",
     "license": "MIT",
     "dependencies": {
-        "@azure/msal-node": "^2.6.0"
+        "@azure/msal-node": "^2.13.1"
     },
     "devDependencies": {
         "tap": "^18.6.1"


### PR DESCRIPTION
Bumping dependencies used in the exercises - to "keep up to date".
The dependencies are not really used directly in the exercises, but we should still keep them up-to-date.
