### PR TITLE
chore(ex-05): update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,4 +6,4 @@ repos:
       description: Detect secrets in our data.
       entry: bash -c 'trufflehog git file://. --no-update --no-verification --fail --since-commit HEAD'
       language: system
-      stages: ["commit", "push"]
+      stages: ["pre-commit", "pre-push"]


### PR DESCRIPTION
"Migrating" the `pre-commit` configuration to the latest version.
When running `pre-commit install` we are getting the following:

```bash
pre-commit install
[WARNING] hook id `trufflehog` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
pre-commit installed at .git/hooks/pre-commit
```

So running `pre-commit migrate-config` to migrate the configuration to the latest version.